### PR TITLE
Add 2xsal, super-eagle, scale2xplus, and sharp-bilinear-simple shaders.

### DIFF
--- a/cg/eagle/shaders/super-eagle.glsl
+++ b/cg/eagle/shaders/super-eagle.glsl
@@ -1,0 +1,175 @@
+int GET_RESULT(float A, float B, float C, float D)
+{
+	int x = 0; int y = 0; int r = 0;
+	if (A == C) x+=1; else if (B == C) y+=1;
+	if (A == D) x+=1; else if (B == D) y+=1;
+	if (x <= 1) r+=1; 
+	if (y <= 1) r-=1;
+	return r;
+}
+const static float3 dtt = float3(65536,255,1);
+float reduce(half3 color)
+{
+	return dot(color, dtt);
+}
+
+#if defined(VERTEX)
+void main(
+  float2 TexCoord,
+  float4 VertexCoord,
+  float4 Color,
+  uniform float2 TextureSize,
+  uniform float4x4 MVPMatrix,
+  float4 out oPosition : POSITION,
+  float2 out oTexCoord : TEXCOORD0,
+  float4 out oTexCoord1 : TEXCOORD1,
+  float4 out oTexCoord2 : TEXCOORD2,
+  float4 out oTexCoord3 : TEXCOORD3,
+  float4 out oTexCoord4 : TEXCOORD4,
+  float4 out oTexCoord5 : TEXCOORD5,
+  float4 out oTexCoord6 : TEXCOORD6,
+  float4 out oTexCoord7 : TEXCOORD7,
+  float4 out oTexCoord8 : TEXCOORD8)
+{
+	oPosition = mul(VertexCoord, MVPMatrix);
+
+	float2 ps = float2(1.0/TextureSize.x, 1.0/TextureSize.y);
+	float dx = ps.x;
+	float dy = ps.y;
+
+	oTexCoord = TexCoord; // E
+	oTexCoord1.xy = TexCoord + half2(-dx,-dy);
+	oTexCoord1.zw = TexCoord + half2(-dx,  0);
+	oTexCoord2.xy = TexCoord + half2(+dx,-dy);
+	oTexCoord2.zw = TexCoord + half2(+dx+dx,-dy);
+	oTexCoord3.xy = TexCoord + half2(-dx,  0);
+	oTexCoord3.zw = TexCoord + half2(+dx,  0);
+	oTexCoord4.xy = TexCoord + half2(+dx+dx,  0);
+	oTexCoord4.zw = TexCoord + half2(-dx,+dy);
+	oTexCoord5.xy = TexCoord + half2(  0,+dy);
+	oTexCoord5.zw = TexCoord + half2(+dx,+dy);
+	oTexCoord6.xy = TexCoord + half2(+dx+dx,+dy);
+	oTexCoord6.zw = TexCoord + half2(-dx,+dy+dy);
+	oTexCoord7.xy = TexCoord + half2(  0,+dy+dy);
+	oTexCoord7.zw = TexCoord + half2(+dx,+dy+dy);
+	oTexCoord8.xy = TexCoord + half2(+dx+dx,+dy+dy);
+}
+#elif defined(FRAGMENT)
+void main(
+  uniform sampler2D decal,
+  uniform float2 TextureSize,
+  float2 TexCoord : TEXCOORD0,
+  float4 oTexCoord1 : TEXCOORD1,
+  float4 oTexCoord2 : TEXCOORD2,
+  float4 oTexCoord3 : TEXCOORD3,
+  float4 oTexCoord4 : TEXCOORD4,
+  float4 oTexCoord5 : TEXCOORD5,
+  float4 oTexCoord6 : TEXCOORD6,
+  float4 oTexCoord7 : TEXCOORD7,
+  float4 oTexCoord8 : TEXCOORD8,
+  float4 out oColor : COLOR
+)
+{
+   float2 fp = frac(TexCoord* TextureSize);
+	// Reading the texels
+
+	half3 C0 = tex2D(decal,oTexCoord1.xy).xyz; 
+	half3 C1 = tex2D(decal,oTexCoord1.zw).xyz;
+	half3 C2 = tex2D(decal,oTexCoord2.xy).xyz;
+	half3 D3 = tex2D(decal,oTexCoord2.zw).xyz;
+	half3 C3 = tex2D(decal,oTexCoord3.xy).xyz;
+	half3 C4 = tex2D(decal,TexCoord).xyz;
+	half3 C5 = tex2D(decal,oTexCoord3.zw).xyz;
+	half3 D4 = tex2D(decal,oTexCoord4.xy).xyz;
+	half3 C6 = tex2D(decal,oTexCoord4.zw).xyz;
+	half3 C7 = tex2D(decal,oTexCoord5.xy).xyz;
+	half3 C8 = tex2D(decal,oTexCoord5.zw).xyz;
+	half3 D5 = tex2D(decal,oTexCoord6.xy).xyz;
+	half3 D0 = tex2D(decal,oTexCoord6.zw).xyz;
+	half3 D1 = tex2D(decal,oTexCoord7.xy).xyz;
+	half3 D2 = tex2D(decal,oTexCoord7.zw).xyz;
+	half3 D6 = tex2D(decal,oTexCoord8.xy).xyz;
+
+	half3 p00,p10,p01,p11;
+
+	// reducing half3 to float	
+	float c0 = reduce(C0);float c1 = reduce(C1);
+	float c2 = reduce(C2);float c3 = reduce(C3);
+	float c4 = reduce(C4);float c5 = reduce(C5);
+	float c6 = reduce(C6);float c7 = reduce(C7);
+	float c8 = reduce(C8);float d0 = reduce(D0);
+	float d1 = reduce(D1);float d2 = reduce(D2);
+	float d3 = reduce(D3);float d4 = reduce(D4);
+	float d5 = reduce(D5);float d6 = reduce(D6);
+
+	/*              SuperEagle code               */
+	/*  Copied from the Dosbox source code        */
+	/*  Copyright (C) 2002-2007  The DOSBox Team  */
+	/*  License: GNU-GPL                          */
+	/*  Adapted by guest(r) on 16.4.2007          */       
+	if (c4 != c8) {
+		if (c7 == c5) {
+			p01 = p10 = C7;
+			if ((c6 == c7) || (c5 == c2)) {
+					p00 = 0.25*(3.0*C7+C4);
+			} else {
+					p00 = 0.5*(C4+C5);
+			}
+
+			if ((c5 == d4) || (c7 == d1)) {
+					p11 = 0.25*(3.0*C7+C8);
+			} else {
+					p11 = 0.5*(C7+C8);
+			}
+		} else {
+			p11 = 0.125*(6.0*C8+C7+C5);
+			p00 = 0.125*(6.0*C4+C7+C5);
+
+			p10 = 0.125*(6.0*C7+C4+C8);
+			p01 = 0.125*(6.0*C5+C4+C8);
+		}
+	} else {
+		if (c7 != c5) {
+			p11 = p00 = C4;
+
+			if ((c1 == c4) || (c8 == d5)) {
+					p01 = 0.25*(3.0*C4+C5);
+			} else {
+					p01 = 0.5*(C4+C5);
+			}
+
+			if ((c8 == d2) || (c3 == c4)) {
+					p10 = 0.25*(3.0*C4+C7);
+			} else {
+					p10 = 0.5*(C7+C8);
+			}
+		} else {
+			int r = 0;
+			r += GET_RESULT(c5,c4,c6,d1);
+			r += GET_RESULT(c5,c4,c3,c1);
+			r += GET_RESULT(c5,c4,d2,d5);
+			r += GET_RESULT(c5,c4,c2,d4);
+
+			if (r > 0) {
+					p01 = p10 = C7;
+					p00 = p11 = 0.5*(C4+C5);
+			} else if (r < 0) {
+					p11 = p00 = C4;
+					p01 = p10 = 0.5*(C4+C5);
+			} else {
+					p11 = p00 = C4;
+					p01 = p10 = C7;
+			}
+		}
+	}
+
+
+
+	// Distributing the four products
+
+	p10 = (fp.x < 0.50) ? (fp.y < 0.50 ? p00 : p10) : (fp.y < 0.50 ? p01: p11);
+
+	// OUTPUT
+	oColor = float4(p10, 1);
+}
+#endif

--- a/cg/eagle/super-eagle.glslp
+++ b/cg/eagle/super-eagle.glslp
@@ -1,0 +1,4 @@
+shaders = "1"
+
+shader0 = "shaders/super-eagle.glsl"
+filter_linear0 = "false"

--- a/cg/scalex/scale2x.glslp
+++ b/cg/scalex/scale2x.glslp
@@ -1,0 +1,4 @@
+shaders = "1"
+
+shader0 = "shaders/scale2xplus.glsl"
+filter_linear0 = "false"

--- a/cg/scalex/shaders/scale2xplus.glsl
+++ b/cg/scalex/shaders/scale2xplus.glsl
@@ -1,0 +1,67 @@
+/*
+   Scale2xPlus shader 
+
+   - Copyright (C) 2007 guest(r) - guest.r@gmail.com
+
+   - License: GNU-GPL  
+
+
+   The Scale2x algorithm:
+
+   - Scale2x Homepage: http://scale2x.sourceforge.net/
+
+   - Copyright (C) 2001, 2002, 2003, 2004 Andrea Mazzoleni 
+
+   - License: GNU-GPL  
+
+ */
+#if defined(VERTEX)
+void main(
+  uniform float2 TextureSize,
+  float2 TexCoord,
+  float4 VertexCoord,
+  uniform float4x4 MVPMatrix,
+  float4 out oPosition : POSITION,
+  float2 out oTexCoord : TEXCOORD0,
+  float4 out ot1 : TEXCOORD1,
+  float4 out ot2 : TEXCOORD2)
+{
+	oPosition = mul(VertexCoord, MVPMatrix);
+
+	float2 ps = float2(1.0/TextureSize.x, 1.0/TextureSize.y);
+	float dx = ps.x;
+	float dy = ps.y;
+
+	oTexCoord = TexCoord; // E
+	ot1 = TexCoord.xyxy + float4(  0,-dy,-dx,  0); // B, D
+	ot2 = TexCoord.xyxy + float4( dx,  0,  0, dy); // F
+}
+#elif defined(FRAGMENT)
+void main(
+  uniform sampler2D decal,
+  uniform float2 TextureSize,
+  float2 TexCoord : TEXCOORD0,
+  float4 t1 : TEXCOORD1,
+  float4 t2 : TEXCOORD2,
+  float4 out oColor : COLOR 
+)
+{
+	float2 fp = frac(TexCoord* TextureSize);
+
+	// Reading the texels
+
+	float3 B = tex2D(decal, t1.xy).xyz;
+	float3 D = tex2D(decal, t1.zw).xyz;
+	float3 E = tex2D(decal, TexCoord).xyz;
+	float3 F = tex2D(decal, t2.xy).xyz;
+	float3 H = tex2D(decal, t2.zw).xyz;
+
+	float3 E0 = D == B && B != H && D != F ? D : E;
+	float3 E1 = B == F && B != H && D != F ? F : E;
+	float3 E2 = D == H && B != H && D != F ? D : E;
+	float3 E3 = H == F && B != H && D != F ? F : E;
+
+	// Product interpolation
+	oColor = float4((E3*fp.x+E2*(1-fp.x))*fp.y+(E1*fp.x+E0*(1-fp.x))*(1-fp.y),1);
+}
+#endif

--- a/cg/sharp/shaders/sharp-bilinear-simple.glsl
+++ b/cg/sharp/shaders/sharp-bilinear-simple.glsl
@@ -1,0 +1,56 @@
+/*
+   Author: rsn8887 (based on TheMaister)
+   License: Public domain
+
+   This is an integer prescale filter that should be combined
+   with a bilinear hardware filtering (GL_BILINEAR filter or some such) to achieve
+   a smooth scaling result with minimum blur. This is good for pixelgraphics
+   that are scaled by non-integer factors.
+   
+   The prescale factor and texel coordinates are precalculated
+   in the vertex shader for speed.
+*/
+
+#if defined(VERTEX)
+void main(
+  float2 TexCoord,
+  float2 VertexCoord,
+  uniform float4x4 MVPMatrix,
+  uniform float2 TextureSize,
+  uniform float2 InputSize,
+  uniform float2 OutputSize,
+  out float4 oPosition : POSITION,
+  out float2 oTexCoord : TEXCOORD0,
+  out float2 texel : TEXCOORD1,
+  out float2 scale : TEXCOORD2)
+{
+    oPosition = mul(float4(VertexCoord, 0.0, 1.0), MVPMatrix);
+    oTexCoord = TexCoord;
+    texel = TexCoord * float4(TextureSize, 1.0 / TextureSize).xy;
+    scale = max(floor(float4(OutputSize, 1.0 / OutputSize).xy / InputSize.xy), float2(1.0, 1.0));
+}
+#elif defined(FRAGMENT)
+void main(
+  uniform sampler2D vTexture,
+  uniform float2 TextureSize,
+  float2 TexCoord : TEXCOORD0,
+  float2 texel : TEXCOORD1,
+  float2 scale : TEXCOORD2,
+  float4 out oColor : COLOR
+)
+{
+   float2 texel_floored = floor(texel);
+   float2 s = frac(texel);
+   float2 region_range = 0.5 - 0.5 / scale;
+
+   // Figure out where in the texel to sample to get correct pre-scaled bilinear.
+   // Uses the hardware bilinear interpolator to avoid having to sample 4 times manually.
+
+   float2 center_dist = s - 0.5;
+   float2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * scale + 0.5;
+
+   float2 mod_texel = texel_floored + f;
+
+   oColor = float4(tex2D(vTexture, mod_texel / float4(TextureSize, 1.0 / TextureSize).xy).rgb, 1.0);
+}
+#endif

--- a/cg/sharp/sharp-bilinear-simple.glslp
+++ b/cg/sharp/sharp-bilinear-simple.glslp
@@ -1,0 +1,4 @@
+shaders = "1"
+
+shader0 = "shaders/sharp-bilinear-simple.glsl"
+filter_linear0 = "true"

--- a/cg/xsal/2xsal.glslp
+++ b/cg/xsal/2xsal.glslp
@@ -1,0 +1,4 @@
+shaders = "1"
+
+shader0 = "shaders/2xsal.glsl"
+filter_linear0 = "true"

--- a/cg/xsal/shaders/2xsal.glsl
+++ b/cg/xsal/shaders/2xsal.glsl
@@ -1,0 +1,56 @@
+/*
+
+   Copyright (C) 2007 guest(r) - guest.r@gmail.com
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+#if defined(VERTEX)
+void main(
+  float2 TexCoord,
+  float2 VertexCoord,
+  float4 Color,
+  uniform float4x4 MVPMatrix,
+  float4 out oPosition : POSITION,
+  float2 out oTexCoord : TEXCOORD0)
+{
+  oPosition = mul(float4(VertexCoord, 0.0, 1.0), MVPMatrix);
+  oTexCoord = TexCoord;
+}
+#elif defined(FRAGMENT)
+void main(
+  uniform sampler2D vTexture,
+  uniform float2 TextureSize,
+  float2 TexCoord : TEXCOORD0,
+  float4 out oColor : COLOR
+)
+{
+   float2 texsize = float4(TextureSize, 1.0 / TextureSize).xy;
+   float dx = pow(texsize.x, -1.0) * 0.25;
+   float dy = pow(texsize.y, -1.0) * 0.25;
+   float3 dt = float3(1.0, 1.0, 1.0);
+
+   float3 c00 = tex2D(vTexture, TexCoord + float2(-dx, -dy)).xyz;
+   float3 c20 = tex2D(vTexture, TexCoord + float2(dx, -dy)).xyz;
+   float3 c02 = tex2D(vTexture, TexCoord + float2(-dx, dy)).xyz;
+   float3 c22 = tex2D(vTexture, TexCoord + float2(dx, dy)).xyz;
+
+   float m1=dot(abs(c00-c22),dt)+0.001;
+   float m2=dot(abs(c02-c20),dt)+0.001;
+
+   oColor = float4((m1*(c02+c20)+m2*(c22+c00))/(2.0*(m1+m2)),1.0);
+}
+#endif


### PR DESCRIPTION
Added some more shaders.
2xsal
super-eagle
scale2xplus
sharp-bilinear-simple

There's some quirks that I couldn't work out.
Attempting to set the shader scale causes the display to shrink to 1/4.
This also means trying to use more than one shader does the above too as it implicitly sets the shader scale.

Any idea why that happens?

